### PR TITLE
Defer to compileOpts.systemGlobal for System definition if defined.

### DIFF
--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -27,14 +27,14 @@ sass.importer((request, done) => {
   });
 });
 
-export default loads => {
+export default (loads, compileOpts) => {
   return new Promise((resolve, reject) => {
     loads.forEach((load) => {
       // TODO Support different load addresses
       urlBase = load.address;
     });
     const stubDefines = loads.map(load => {
-      return `System\.register('${load.name}', [], false, function() {});`;
+      return `${(compileOpts.systemGlobal || 'System')}\.register('${load.name}', [], false, function() {});`;
     }).join('\n');
     const scss = loads.map(load => {
       return load.source;


### PR DESCRIPTION
Defer to `compileOpts.systemGlobal` for System reference if defined.

Fixes an issues when creating sfx bundles, where the global System reference is defined as `$__System` but plugin-sass uses the hard coded `System`, leading to an Uncaught ReferenceError.