### PR TITLE
Support for SASS partial references.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dependencies": {
       "fetch": "npm:whatwg-fetch@^0.9.0",
       "fs": "github:jspm/nodelibs-fs@^0.1.2",
+      "querystring": "github:jspm/nodelibs-querystring@^0.1.0",
       "sass.js": "npm:sass.js@^0.9.2",
       "url": "github:jspm/nodelibs-url@^0.1.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plugin-sass",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "description": "SystemJS SASS loader plugin",
   "registry": "jspm",
   "main": "sass.js",

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,7 @@ System.config({
     "core-js": "npm:core-js@1.2.0",
     "fetch": "npm:whatwg-fetch@0.9.0",
     "fs": "github:jspm/nodelibs-fs@0.1.2",
+    "querystring": "github:jspm/nodelibs-querystring@0.1.0",
     "sass.js": "npm:sass.js@0.9.2",
     "scss": "index.js",
     "url": "github:jspm/nodelibs-url@0.1.0",
@@ -43,6 +44,9 @@ System.config({
     },
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
+    },
+    "github:jspm/nodelibs-querystring@0.1.0": {
+      "querystring": "npm:querystring@0.2.0"
     },
     "github:jspm/nodelibs-stream@0.1.0": {
       "stream-browserify": "npm:stream-browserify@1.0.0"

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -44,7 +44,7 @@ sass.importer((request, done) => {
     .then(data => content = data)
     .catch(() => loadFile(readImportPath))
     .then(data => content = data)
-    .then(() => done({ content }))
+    .then(() => done({ content }));
 });
 
 export default (loads, compileOpts) => {

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -1,12 +1,13 @@
-import url from 'url';
 import fs from 'fs';
+import querystring from 'querystring';
 import sass from 'sass.js';
+import url from 'url';
 
 const cssInject = "(function(c){var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})";
 
 let urlBase;
 
-function escape(source) {
+const escape = source => {
   return source
     .replace(/(["\\])/g, '\\$1')
     .replace(/[\f]/g, '\\f')
@@ -16,15 +17,34 @@ function escape(source) {
     .replace(/[\r]/g, '\\r')
     .replace(/[\u2028]/g, '\\u2028')
     .replace(/[\u2029]/g, '\\u2029');
-}
+};
+
+const loadFile = path => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(path, {encoding: 'UTF-8'}, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+};
 
 // intercept file loading requests (@import directive) from libsass
 sass.importer((request, done) => {
-  const fullUrl = url.resolve(urlBase, `${request.current}.scss`);
-  const readUrl = url.parse(fullUrl).path;
-  fs.readFile(readUrl, {encoding: 'UTF-8'}, (err, data) => {
-    done({ content: data });
-  });
+  const importUrl = url.resolve(urlBase, `${request.current}.scss`);
+  const partialUrl = importUrl.replace(/\/([^/]*)$/, '/_$1');
+
+  const readImportPath = querystring.unescape(url.parse(importUrl).path);
+  const readPartialPath = querystring.unescape(url.parse(partialUrl).path);
+
+  let content;
+  loadFile(readPartialPath)
+    .then(data => content = data)
+    .catch(() => loadFile(readImportPath))
+    .then(data => content = data)
+    .then(() => done({ content }))
 });
 
 export default (loads, compileOpts) => {

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -5,12 +5,29 @@ import fs from 'fs';
 
 let urlBase;
 
+const loadFile = loadUrl => {
+  return fetch(loadUrl)
+    .then(response => {
+      if (response.status === 404) {
+        throw new Error('Not found');
+      }
+      return response.text();
+    });
+};
+
 // intercept file loading requests (@import directive) from libsass
 sass.importer((request, done) => {
-  const importUrl = url.resolve(urlBase, request.current + '.scss');
-  fetch(importUrl)
-    .then(response => response.text())
-    .then(content => done({ content }));
+  const { current } = request;
+
+  const importUrl = url.resolve(urlBase, `${current}.scss`);
+  const partialUrl = importUrl.replace(/\/([^/]*)$/, '/_$1');
+
+  let content;
+  loadFile(partialUrl)
+    .then(data => content = data)
+    .catch(() => loadFile(importUrl))
+    .then(data => content = data)
+    .then(() => done({ content }))
 });
 
 const compile = scss => {

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -27,7 +27,7 @@ sass.importer((request, done) => {
     .then(data => content = data)
     .catch(() => loadFile(importUrl))
     .then(data => content = data)
-    .then(() => done({ content }))
+    .then(() => done({ content }));
 });
 
 const compile = scss => {

--- a/test/bundle-test.jade
+++ b/test/bundle-test.jade
@@ -10,8 +10,11 @@ html
     script(type='text/javascript').
       System.import('test/bundleme')
         .then(() => {
-          document.body.innerHTML += '<h2>Loading done</h2>';
+            document.addEventListener('DOMContentLoaded', (event) => {
+                document.body.innerHTML += '<h2>Loading done</h2>';
+            });
         });
   body
-    h1 I should become blue and background should become green
+    h1 I should become blue and background should show a SASS logo
     h2 Loading...
+    p I SHOULD BE ALL LOWERCASE

--- a/test/runtime-test.jade
+++ b/test/runtime-test.jade
@@ -14,3 +14,4 @@ html
   body
     h1 I should become blue and background should show a SASS logo
     h2 Loading...
+    p I SHOULD BE ALL LOWERCASE

--- a/test/styles/_typography.scss
+++ b/test/styles/_typography.scss
@@ -1,0 +1,3 @@
+p {
+  text-transform: lowercase;
+}

--- a/test/styles/test.scss
+++ b/test/styles/test.scss
@@ -1,4 +1,5 @@
 @import 'headings';
+@import 'typography';
 
 $image: '../images/sass-logo.svg';
 


### PR DESCRIPTION
When importing a SCSS file from another SCSS file, the convention is to
have the file be named “_something”, but imported as “something”. This
change supports this, by first requesting (or reading from disk) the _
version, and falling back to the exact filename if it cannot be found.