### PR TITLE
Use Sass.js web worker when supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ Now you can test runtime compilation
 $ gulp test:runtime
 ```
 
-or bundling
+bundling
 
 ```sh
 $ gulp test:bundle
+```
+
+or static bundling
+
+```sh
+$ gulp test:bundleStatic
 ```
 
 After that open [http://localhost:3000](http://localhost:3000) in the browser

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "fetch": "npm:whatwg-fetch@^0.9.0",
       "fs": "github:jspm/nodelibs-fs@^0.1.2",
       "querystring": "github:jspm/nodelibs-querystring@^0.1.0",
-      "sassjs": "npm:sass.js@^0.9.4",
+      "sass.js": "npm:sass.js@^0.9.4",
       "url": "github:jspm/nodelibs-url@^0.1.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "fetch": "npm:whatwg-fetch@^0.9.0",
       "fs": "github:jspm/nodelibs-fs@^0.1.2",
       "querystring": "github:jspm/nodelibs-querystring@^0.1.0",
-      "sass.js": "npm:sass.js@^0.9.2",
+      "sassjs": "npm:sass.js@^0.9.4",
       "url": "github:jspm/nodelibs-url@^0.1.0"
     },
     "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -21,14 +21,14 @@ System.config({
     "fetch": "npm:whatwg-fetch@0.9.0",
     "fs": "github:jspm/nodelibs-fs@0.1.2",
     "querystring": "github:jspm/nodelibs-querystring@0.1.0",
-    "sass.js": "npm:sass.js@0.9.2",
+    "sassjs": "npm:sass.js@0.9.4",
     "scss": "index.js",
     "url": "github:jspm/nodelibs-url@0.1.0",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },
     "github:jspm/nodelibs-buffer@0.1.0": {
-      "buffer": "npm:buffer@3.5.0"
+      "buffer": "npm:buffer@3.5.1"
     },
     "github:jspm/nodelibs-constants@0.1.0": {
       "constants-browserify": "npm:constants-browserify@0.0.1"
@@ -42,8 +42,8 @@ System.config({
     "github:jspm/nodelibs-path@0.1.0": {
       "path-browserify": "npm:path-browserify@0.0.0"
     },
-    "github:jspm/nodelibs-process@0.1.1": {
-      "process": "npm:process@0.10.1"
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
     },
     "github:jspm/nodelibs-querystring@0.1.0": {
       "querystring": "npm:querystring@0.2.0"
@@ -75,12 +75,12 @@ System.config({
       "util": "npm:util@0.10.3"
     },
     "npm:babel-runtime@5.8.25": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:browserify-aes@1.0.5": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "buffer-xor": "npm:buffer-xor@1.0.3",
-      "cipher-base": "npm:cipher-base@1.0.1",
+      "cipher-base": "npm:cipher-base@1.0.2",
       "create-hash": "npm:create-hash@1.1.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "evp_bytestokey": "npm:evp_bytestokey@1.0.0",
@@ -97,7 +97,7 @@ System.config({
     },
     "npm:browserify-des@1.0.0": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "cipher-base": "npm:cipher-base@1.0.1",
+      "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "des.js": "npm:des.js@1.0.0",
       "inherits": "npm:inherits@2.0.1"
@@ -125,12 +125,12 @@ System.config({
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
-    "npm:buffer@3.5.0": {
+    "npm:buffer@3.5.1": {
       "base64-js": "npm:base64-js@0.0.8",
       "ieee754": "npm:ieee754@1.1.6",
       "is-array": "npm:is-array@1.0.1"
     },
-    "npm:cipher-base@1.0.1": {
+    "npm:cipher-base@1.0.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "inherits": "npm:inherits@2.0.1",
       "stream": "github:jspm/nodelibs-stream@0.1.0",
@@ -141,13 +141,13 @@ System.config({
     },
     "npm:core-js@1.2.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
     "npm:core-util-is@1.0.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0"
     },
-    "npm:create-ecdh@2.0.1": {
+    "npm:create-ecdh@2.0.2": {
       "bn.js": "npm:bn.js@2.2.0",
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
@@ -155,7 +155,7 @@ System.config({
     },
     "npm:create-hash@1.1.2": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "cipher-base": "npm:cipher-base@1.0.1",
+      "cipher-base": "npm:cipher-base@1.0.2",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "inherits": "npm:inherits@2.0.1",
@@ -172,7 +172,7 @@ System.config({
     "npm:crypto-browserify@3.10.0": {
       "browserify-cipher": "npm:browserify-cipher@1.0.0",
       "browserify-sign": "npm:browserify-sign@3.0.8",
-      "create-ecdh": "npm:create-ecdh@2.0.1",
+      "create-ecdh": "npm:create-ecdh@2.0.2",
       "create-hash": "npm:create-hash@1.1.2",
       "create-hmac": "npm:create-hmac@1.1.4",
       "diffie-hellman": "npm:diffie-hellman@3.0.2",
@@ -226,7 +226,7 @@ System.config({
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
     },
     "npm:path-browserify@0.0.0": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:pbkdf2@3.0.4": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -234,8 +234,11 @@ System.config({
       "create-hmac": "npm:create-hmac@1.1.4",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
     },
     "npm:public-encrypt@2.0.1": {
       "bn.js": "npm:bn.js@2.2.0",
@@ -247,12 +250,12 @@ System.config({
       "randombytes": "npm:randombytes@2.0.1"
     },
     "npm:punycode@1.3.2": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:randombytes@2.0.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:readable-stream@1.1.13": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -260,26 +263,26 @@ System.config({
       "events": "github:jspm/nodelibs-events@0.1.1",
       "inherits": "npm:inherits@2.0.1",
       "isarray": "npm:isarray@0.0.1",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "stream-browserify": "npm:stream-browserify@1.0.0",
       "string_decoder": "npm:string_decoder@0.10.31"
     },
     "npm:ripemd160@1.0.1": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
-    "npm:sass.js@0.9.2": {
+    "npm:sass.js@0.9.4": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "crypto": "github:jspm/nodelibs-crypto@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:sha.js@2.4.4": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "inherits": "npm:inherits@2.0.1",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:stream-browserify@1.0.0": {
       "events": "github:jspm/nodelibs-events@0.1.1",
@@ -297,7 +300,7 @@ System.config({
     },
     "npm:util@0.10.3": {
       "inherits": "npm:inherits@2.0.1",
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:vm-browserify@0.0.4": {
       "indexof": "npm:indexof@0.0.1"

--- a/src/config.js
+++ b/src/config.js
@@ -21,7 +21,7 @@ System.config({
     "fetch": "npm:whatwg-fetch@0.9.0",
     "fs": "github:jspm/nodelibs-fs@0.1.2",
     "querystring": "github:jspm/nodelibs-querystring@0.1.0",
-    "sassjs": "npm:sass.js@0.9.4",
+    "sass.js": "npm:sass.js@0.9.4",
     "scss": "index.js",
     "url": "github:jspm/nodelibs-url@0.1.0",
     "github:jspm/nodelibs-assert@0.1.0": {

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import querystring from 'querystring';
-import sass from 'sassjs';
+import sass from 'sass.js';
 import url from 'url';
 
 const cssInject = "(function(c){var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})";

--- a/src/sass-builder.js
+++ b/src/sass-builder.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import querystring from 'querystring';
-import sass from 'sass.js';
+import sass from 'sassjs';
 import url from 'url';
 
 const cssInject = "(function(c){var d=document,a='appendChild',i='styleSheet',s=d.createElement('style');s.type='text/css';d.getElementsByTagName('head')[0][a](s);s[i]?s[i].cssText=c:s[a](d.createTextNode(c));})";

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -4,8 +4,6 @@ import fs from 'fs';
 
 let urlBase;
 
-window.Worker = null;
-
 const Sass = new Promise((resolve, reject) => {
   let _sass;
   if (typeof window.Worker === 'function') {

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -1,8 +1,9 @@
 import 'fetch';
 import url from 'url';
-import sass from 'sass.js';
+import Sass from 'sass.js/dist/sass';
 import fs from 'fs';
 
+const sass = new Sass();
 let urlBase;
 
 const loadFile = loadUrl => {

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -7,11 +7,11 @@ let urlBase;
 const Sass = new Promise((resolve, reject) => {
   let _sass;
   if (typeof window.Worker === 'function') {
-    System.import('sass.js/dist/sass').then(sass => {
+    System.import('sass.js/dist/sass', __moduleName).then(sass => {
       resolve(new sass());
     }).catch(err => reject(err));
   } else {
-    System.import('sass.js/dist/sass.sync').then(sass => {
+    System.import('sass.js/dist/sass.sync', __moduleName).then(sass => {
       resolve(sass);
     });
   }

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -4,15 +4,14 @@ import fs from 'fs';
 
 let urlBase;
 
-const Sass = new Promise((resolve, reject) => {
-  let _sass;
+const importSass = new Promise((resolve, reject) => {
   if (typeof window.Worker === 'function') {
-    System.import('sass.js/dist/sass', __moduleName).then(sass => {
-      resolve(new sass());
+    System.import('sass.js/dist/sass', __moduleName).then(Sass => {
+      resolve(new Sass());
     }).catch(err => reject(err));
   } else {
-    System.import('sass.js/dist/sass.sync', __moduleName).then(sass => {
-      resolve(sass);
+    System.import('sass.js/dist/sass.sync', __moduleName).then(Sass => {
+      resolve(Sass);
     });
   }
 });
@@ -28,7 +27,7 @@ const loadFile = loadUrl => {
 };
 
 // intercept file loading requests (@import directive) from libsass
-Sass.then((sass) => {
+importSass.then((sass) => {
   sass.importer((request, done) => {
     const { current } = request;
 
@@ -47,7 +46,7 @@ Sass.then((sass) => {
 
 const compile = scss => {
   return new Promise((resolve, reject) => {
-    Sass.then(sass => {
+    importSass.then(sass => {
       sass.compile(scss, result => {
         if (result.status === 0) {
           const style = document.createElement('style');
@@ -59,7 +58,7 @@ const compile = scss => {
           reject(result.formatted);
         }
       });
-    })
+    });
   });
 };
 

--- a/src/sass-inject.js
+++ b/src/sass-inject.js
@@ -7,11 +7,11 @@ let urlBase;
 const Sass = new Promise((resolve, reject) => {
   let _sass;
   if (typeof window.Worker === 'function') {
-    System.import('sassjs/dist/sass').then(sass => {
+    System.import('sass.js/dist/sass').then(sass => {
       resolve(new sass());
     }).catch(err => reject(err));
   } else {
-    System.import('sassjs/dist/sass.sync').then(sass => {
+    System.import('sass.js/dist/sass.sync').then(sass => {
       resolve(sass);
     });
   }

--- a/test/bundle-static-test.jade
+++ b/test/bundle-static-test.jade
@@ -1,0 +1,10 @@
+doctype html
+html
+  head
+    title Test
+    meta(charset='utf-8')
+    meta(http-equiv='Content-Type', content='text/html; charset=UTF-8')
+    script(src='bundle.js')
+  body
+    h1 I should become blue and background should show a SASS logo
+    p I SHOULD BE ALL LOWERCASE


### PR DESCRIPTION
The use of the web worker version of Sass.js is preferable in browsers that support it. This pull request checks for Worker support and imports the appropriate version of Sass.js.

I've also added a test:bundleStatic task to the gulpfile to help avoid static bundling issues.